### PR TITLE
163163277 fault tolerance content api

### DIFF
--- a/__tests__/__mocks__/response-without-category.json
+++ b/__tests__/__mocks__/response-without-category.json
@@ -1,0 +1,179 @@
+{
+    "sys": {
+      "type": "Array"
+    },
+    "total": 1,
+    "skip": 0,
+    "limit": 100,
+    "items": [
+      {
+        "sys": {
+          "space": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Space",
+              "id": "6tuem73u73an"
+            }
+          },
+          "id": "1Lc6Z3TJ4kMYmwMemsu6Cs",
+          "type": "Entry",
+          "createdAt": "2017-12-07T21:16:41.189Z",
+          "updatedAt": "2017-12-07T21:16:41.189Z",
+          "revision": 1,
+          "contentType": {
+            "sys": {
+              "type": "Link",
+              "linkType": "ContentType",
+              "id": "article"
+            }
+          },
+          "locale": "en-US"
+        },
+        "fields": {
+          "title": "Article title",
+          "tags": ["foo", "bar"],
+          "author": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Entry",
+              "id": "3wNHo4lB7qOMgWyaOCK4C4"
+            }
+          },
+          "publicationDate": "2017-12-07T07:00-08:00",
+          "contentSummary": "Content summary",
+          "heroImage": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Asset",
+              "id": "2B1vKpr1N62AaqK248oCs8"
+            }
+          },
+          "thumbImage": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Asset",
+              "id": "1nm86JeV2kEa86UUaIEcWm"
+            }
+          },
+          "body": "The body of the content (//images.contentful.com/6tuem73u73an/1QXPHgEwraG00mugw08uSe/d198d126ba821c50ce94d7a3302ae267/TestImage1.jpeg) (//images.ctfassets.net/6tuem73u73an/1QXPHgEwraG00mugw08uSe/d198d126ba821c50ce94d7a3302ae267/TestImage2.jpeg)",
+          "parentPage": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Entry",
+              "id": "1r8sBYA0mcYcisuIIQAyaM"
+            }
+          },
+          "slug": "article-title",
+          "categories": [
+            {
+              "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "27aCQsanUkumUkWGga40c6"
+              }
+            }
+          ],
+          "staging": true,
+          "production": true,
+          "indexed": true
+        }
+      }
+    ],
+    "includes": {
+      "Entry": [
+        {
+          "sys": {
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "6tuem73u73an"
+              }
+            },
+            "id": "1r8sBYA0mcYcisuIIQAyaM",
+            "type": "Entry",
+            "createdAt": "2017-12-07T21:16:41.111Z",
+            "updatedAt": "2017-12-07T21:16:41.111Z",
+            "revision": 1,
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "page"
+              }
+            },
+            "locale": "en-US"
+          },
+          "fields": {
+            "name": "Ford Mustang Page",
+            "description": "Page about Ford Mustangs",
+            "slug": "ford-mustang"
+          }
+        },
+        {
+          "sys": {
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "6tuem73u73an"
+              }
+            },
+            "id": "3wNHo4lB7qOMgWyaOCK4C4",
+            "type": "Entry",
+            "createdAt": "2017-12-07T21:16:41.105Z",
+            "updatedAt": "2017-12-07T21:16:41.105Z",
+            "revision": 1,
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "author"
+              }
+            },
+            "locale": "en-US"
+          },
+          "fields": {
+            "name": "Ben Kempner",
+            "title": "Chief Word Guy",
+            "email": "ben@autolist.com"
+          }
+        }
+      ],
+      "Asset": [
+        {
+          "sys": {
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "6tuem73u73an"
+              }
+            },
+            "id": "2B1vKpr1N62AaqK248oCs8",
+            "type": "Asset",
+            "createdAt": "2017-12-08T00:28:49.671Z",
+            "updatedAt": "2017-12-08T00:28:49.671Z",
+            "revision": 1,
+            "locale": "en-US"
+          },
+          "fields": {
+            "title": "Hero Image Example",
+            "description": "Description example in English",
+            "file": {
+              "url": "//images.contentful.com/6tuem73u73an/2B1vKpr1N62AaqK248oCs8/8d4ac9bf8897d0700880b4f3acfe9f28/hero_image_example.png",
+              "details": {
+                "size": 14969,
+                "image": {
+                  "width": 1140,
+                  "height": 107
+                }
+              },
+              "fileName": "hero_image_example.png",
+              "contentType": "image/png"
+            }
+          }
+        }
+      ]
+    }
+  }

--- a/__tests__/__mocks__/response.json
+++ b/__tests__/__mocks__/response.json
@@ -5,225 +5,203 @@
   "total": 1,
   "skip": 0,
   "limit": 100,
-  "items": [{
-    "sys": {
-      "space": {
-        "sys": {
-          "type": "Link",
-          "linkType": "Space",
-          "id": "6tuem73u73an"
-        }
+  "items": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6tuem73u73an"
+          }
+        },
+        "id": "1Lc6Z3TJ4kMYmwMemsu6Cs",
+        "type": "Entry",
+        "createdAt": "2017-12-07T21:16:41.189Z",
+        "updatedAt": "2017-12-07T21:16:41.189Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "article"
+          }
+        },
+        "locale": "en-US"
       },
-      "id": "1Lc6Z3TJ4kMYmwMemsu6Cs",
-      "type": "Entry",
-      "createdAt": "2017-12-07T21:16:41.189Z",
-      "updatedAt": "2017-12-07T21:16:41.189Z",
-      "revision": 1,
-      "contentType": {
-        "sys": {
-          "type": "Link",
-          "linkType": "ContentType",
-          "id": "article"
-        }
-      },
-      "locale": "en-US"
-    },
-    "fields": {
-      "title": "Article title",
-      "tags": ["foo", "bar"],
-      "author": {
-        "sys": {
-          "type": "Link",
-          "linkType": "Entry",
-          "id": "3wNHo4lB7qOMgWyaOCK4C4"
-        }
-      },
-      "publicationDate": "2017-12-07T07:00-08:00",
-      "contentSummary": "Content summary",
-      "heroImage": {
-        "sys": {
-          "type": "Link",
-          "linkType": "Asset",
-          "id": "2B1vKpr1N62AaqK248oCs8"
-        }
-      },
-      "thumbImage": {
-        "sys": {
-          "type": "Link",
-          "linkType": "Asset",
-          "id": "1nm86JeV2kEa86UUaIEcWm"
-        }
-      },
-      "body": "The body of the content (//images.contentful.com/6tuem73u73an/1QXPHgEwraG00mugw08uSe/d198d126ba821c50ce94d7a3302ae267/TestImage1.jpeg) (//images.ctfassets.net/6tuem73u73an/1QXPHgEwraG00mugw08uSe/d198d126ba821c50ce94d7a3302ae267/TestImage2.jpeg)",
-      "parentPage": {
-        "sys": {
-          "type": "Link",
-          "linkType": "Entry",
-          "id": "1r8sBYA0mcYcisuIIQAyaM"
-        }
-      },
-      "slug": "article-title",
-      "categories": [{
-        "sys": {
-          "type": "Link",
-          "linkType": "Entry",
-          "id": "27aCQsanUkumUkWGga40c6"
-        }
-      }],
-      "staging": true,
-      "production": true,
-      "indexed": true
+      "fields": {
+        "title": "Article title",
+        "tags": ["foo", "bar"],
+        "author": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Entry",
+            "id": "3wNHo4lB7qOMgWyaOCK4C4"
+          }
+        },
+        "publicationDate": "2017-12-07T07:00-08:00",
+        "contentSummary": "Content summary",
+        "heroImage": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Asset",
+            "id": "2B1vKpr1N62AaqK248oCs8"
+          }
+        },
+        "thumbImage": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Asset",
+            "id": "1nm86JeV2kEa86UUaIEcWm"
+          }
+        },
+        "body": "The body of the content (//images.contentful.com/6tuem73u73an/1QXPHgEwraG00mugw08uSe/d198d126ba821c50ce94d7a3302ae267/TestImage1.jpeg) (//images.ctfassets.net/6tuem73u73an/1QXPHgEwraG00mugw08uSe/d198d126ba821c50ce94d7a3302ae267/TestImage2.jpeg)",
+        "parentPage": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Entry",
+            "id": "1r8sBYA0mcYcisuIIQAyaM"
+          }
+        },
+        "slug": "article-title",
+        "categories": [
+          {
+            "sys": {
+              "type": "Link",
+              "linkType": "Entry",
+              "id": "27aCQsanUkumUkWGga40c6"
+            }
+          }
+        ],
+        "staging": true,
+        "production": true,
+        "indexed": true
+      }
     }
-  }],
+  ],
   "includes": {
-    "Entry": [{
-      "sys": {
-        "space": {
-          "sys": {
-            "type": "Link",
-            "linkType": "Space",
-            "id": "6tuem73u73an"
-          }
-        },
-        "id": "1r8sBYA0mcYcisuIIQAyaM",
-        "type": "Entry",
-        "createdAt": "2017-12-07T21:16:41.111Z",
-        "updatedAt": "2017-12-07T21:16:41.111Z",
-        "revision": 1,
-        "contentType": {
-          "sys": {
-            "type": "Link",
-            "linkType": "ContentType",
-            "id": "page"
-          }
-        },
-        "locale": "en-US"
-      },
-      "fields": {
-        "name": "Ford Mustang Page",
-        "description": "Page about Ford Mustangs",
-        "slug": "ford-mustang"
-      }
-    }, {
-      "sys": {
-        "space": {
-          "sys": {
-            "type": "Link",
-            "linkType": "Space",
-            "id": "6tuem73u73an"
-          }
-        },
-        "id": "27aCQsanUkumUkWGga40c6",
-        "type": "Entry",
-        "createdAt": "2017-12-07T21:16:41.179Z",
-        "updatedAt": "2017-12-07T21:16:41.179Z",
-        "revision": 1,
-        "contentType": {
-          "sys": {
-            "type": "Link",
-            "linkType": "ContentType",
-            "id": "category"
-          }
-        },
-        "locale": "en-US"
-      },
-      "fields": {
-        "name": "News & Analysis",
-        "description": "Autos News & Analysis"
-      }
-    }, {
-      "sys": {
-        "space": {
-          "sys": {
-            "type": "Link",
-            "linkType": "Space",
-            "id": "6tuem73u73an"
-          }
-        },
-        "id": "3wNHo4lB7qOMgWyaOCK4C4",
-        "type": "Entry",
-        "createdAt": "2017-12-07T21:16:41.105Z",
-        "updatedAt": "2017-12-07T21:16:41.105Z",
-        "revision": 1,
-        "contentType": {
-          "sys": {
-            "type": "Link",
-            "linkType": "ContentType",
-            "id": "author"
-          }
-        },
-        "locale": "en-US"
-      },
-      "fields": {
-        "name": "Ben Kempner",
-        "title": "Chief Word Guy",
-        "email": "ben@autolist.com"
-      }
-    }],
-    "Asset": [{
-      "sys": {
-        "space": {
-          "sys": {
-            "type": "Link",
-            "linkType": "Space",
-            "id": "6tuem73u73an"
-          }
-        },
-        "id": "1nm86JeV2kEa86UUaIEcWm",
-        "type": "Asset",
-        "createdAt": "2017-12-08T00:28:49.658Z",
-        "updatedAt": "2017-12-08T00:28:49.658Z",
-        "revision": 1,
-        "locale": "en-US"
-      },
-      "fields": {
-        "title": "Thumb image title English",
-        "description": "Thumb image description English",
-        "file": {
-          "url": "//images.ctfassets.net/6tuem73u73an/1nm86JeV2kEa86UUaIEcWm/18e4485592d89cda2cad1f60fde29f7d/thumb-image-example.jpg",
-          "details": {
-            "size": 66313,
-            "image": {
-              "width": 720,
-              "height": 720
+    "Entry": [
+      {
+        "sys": {
+          "space": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Space",
+              "id": "6tuem73u73an"
             }
           },
-          "fileName": "thumb-image-example.jpg",
-          "contentType": "image/jpeg"
-        }
-      }
-    }, {
-      "sys": {
-        "space": {
-          "sys": {
-            "type": "Link",
-            "linkType": "Space",
-            "id": "6tuem73u73an"
-          }
-        },
-        "id": "2B1vKpr1N62AaqK248oCs8",
-        "type": "Asset",
-        "createdAt": "2017-12-08T00:28:49.671Z",
-        "updatedAt": "2017-12-08T00:28:49.671Z",
-        "revision": 1,
-        "locale": "en-US"
-      },
-      "fields": {
-        "title": "Hero Image Example",
-        "description": "Description example in English",
-        "file": {
-          "url": "//images.contentful.com/6tuem73u73an/2B1vKpr1N62AaqK248oCs8/8d4ac9bf8897d0700880b4f3acfe9f28/hero_image_example.png",
-          "details": {
-            "size": 14969,
-            "image": {
-              "width": 1140,
-              "height": 107
+          "id": "1r8sBYA0mcYcisuIIQAyaM",
+          "type": "Entry",
+          "createdAt": "2017-12-07T21:16:41.111Z",
+          "updatedAt": "2017-12-07T21:16:41.111Z",
+          "revision": 1,
+          "contentType": {
+            "sys": {
+              "type": "Link",
+              "linkType": "ContentType",
+              "id": "page"
             }
           },
-          "fileName": "hero_image_example.png",
-          "contentType": "image/png"
+          "locale": "en-US"
+        },
+        "fields": {
+          "name": "Ford Mustang Page",
+          "description": "Page about Ford Mustangs",
+          "slug": "ford-mustang"
+        }
+      },
+      {
+        "sys": {
+          "space": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Space",
+              "id": "6tuem73u73an"
+            }
+          },
+          "id": "27aCQsanUkumUkWGga40c6",
+          "type": "Entry",
+          "createdAt": "2017-12-07T21:16:41.179Z",
+          "updatedAt": "2017-12-07T21:16:41.179Z",
+          "revision": 1,
+          "contentType": {
+            "sys": {
+              "type": "Link",
+              "linkType": "ContentType",
+              "id": "category"
+            }
+          },
+          "locale": "en-US"
+        },
+        "fields": {
+          "name": "News & Analysis",
+          "description": "Autos News & Analysis"
+        }
+      },
+      {
+        "sys": {
+          "space": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Space",
+              "id": "6tuem73u73an"
+            }
+          },
+          "id": "3wNHo4lB7qOMgWyaOCK4C4",
+          "type": "Entry",
+          "createdAt": "2017-12-07T21:16:41.105Z",
+          "updatedAt": "2017-12-07T21:16:41.105Z",
+          "revision": 1,
+          "contentType": {
+            "sys": {
+              "type": "Link",
+              "linkType": "ContentType",
+              "id": "author"
+            }
+          },
+          "locale": "en-US"
+        },
+        "fields": {
+          "name": "Ben Kempner",
+          "title": "Chief Word Guy",
+          "email": "ben@autolist.com"
         }
       }
-    }]
+    ],
+    "Asset": [
+      {
+        "sys": {
+          "space": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Space",
+              "id": "6tuem73u73an"
+            }
+          },
+          "id": "2B1vKpr1N62AaqK248oCs8",
+          "type": "Asset",
+          "createdAt": "2017-12-08T00:28:49.671Z",
+          "updatedAt": "2017-12-08T00:28:49.671Z",
+          "revision": 1,
+          "locale": "en-US"
+        },
+        "fields": {
+          "title": "Hero Image Example",
+          "description": "Description example in English",
+          "file": {
+            "url": "//images.contentful.com/6tuem73u73an/2B1vKpr1N62AaqK248oCs8/8d4ac9bf8897d0700880b4f3acfe9f28/hero_image_example.png",
+            "details": {
+              "size": 14969,
+              "image": {
+                "width": 1140,
+                "height": 107
+              }
+            },
+            "fileName": "hero_image_example.png",
+            "contentType": "image/png"
+          }
+        }
+      }
+    ]
   }
 }

--- a/__tests__/lib/Item.test.js
+++ b/__tests__/lib/Item.test.js
@@ -1,5 +1,6 @@
 import Item from '../../lib/Item';
 import response from '../__mocks__/response.json';
+import responseWithoutCategory from '../__mocks__/response-without-category.json';
 import emptyResponse from '../__mocks__/empty-response.json';
 
 class Article extends Item {}
@@ -53,12 +54,23 @@ describe('Item', () => {
     let article;
 
     describe('with a not found relationship', () => {
-      beforeEach(async () => {
-        [article] = await Article.load(response);
+      describe('singular relationship', () => {
+        beforeEach(async () => {
+          [article] = await Article.load(response);
+        });
+
+        it('is undefined', () => {
+          expect(article.relationships.thumbImage).toBe(undefined);
+        });
       });
 
-      it('is undefined', () => {
-        expect(article.relationships.thumbImage).toBe(undefined);
+      describe('plural relationship', () => {
+        beforeEach(async () => {
+          [article] = await Article.load(responseWithoutCategory);
+        });
+        it('is undefined', () => {
+          expect(article.relationships.categories).toEqual([]);
+        });
       });
     });
   });

--- a/__tests__/lib/Item.test.js
+++ b/__tests__/lib/Item.test.js
@@ -49,6 +49,20 @@ describe('Item', () => {
     });
   });
 
+  describe('relationships', () => {
+    let article;
+
+    describe('with a not found relationship', () => {
+      beforeEach(async () => {
+        [article] = await Article.load(response);
+      });
+
+      it('is undefined', () => {
+        expect(article.relationships.thumbImage).toBe(undefined);
+      });
+    });
+  });
+
   describe('fields', () => {
     let article;
 

--- a/lib/Item.js
+++ b/lib/Item.js
@@ -91,7 +91,7 @@ export default class Item {
     const match = items.find(item => item.id === id);
 
     if (isEmpty(match)) {
-      throw new Error(`No matching record found for ${id} on ${this}`);
+      console.warn(`No matching record found for ${id} on ${this}`);
     }
 
     this.relationships[name] = match;

--- a/lib/Item.js
+++ b/lib/Item.js
@@ -102,13 +102,14 @@ export default class Item {
       const match = items.find(item => item.id === id);
 
       if (isEmpty(match)) {
-        throw new Error(`No matching record found for ${id} on ${this}`);
+        console.warn(`No matching record found for ${id} on ${this}`);
+        return;
+      } else {
+        return match;
       }
 
-      return match;
     });
-
-    this.relationships[name] = matches;
+    this.relationships[name] = matches.filter(match => match);
   }
 
   hasField(key) {

--- a/lib/Item.js
+++ b/lib/Item.js
@@ -103,11 +103,8 @@ export default class Item {
 
       if (isEmpty(match)) {
         console.warn(`No matching record found for ${id} on ${this}`);
-        return;
-      } else {
-        return match;
       }
-
+      return match;
     });
     this.relationships[name] = matches.filter(match => match);
   }


### PR DESCRIPTION
We will remove any missing id entries from the response without removing the content type entry itself. Just confirming that this is the agreed upon behavior for now.